### PR TITLE
Opção de Pacote Separadamente por Cada Produto do Pedido

### DIFF
--- a/includes/class-wc-correios-method-base.php
+++ b/includes/class-wc-correios-method-base.php
@@ -1,0 +1,107 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_Method_Base extends WC_Shipping_Method {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+	//public function __construct( $method_id = 'correios_base', $method_name = 'Correios Base' ) {
+  public function __construct() {
+		// Load the form fields.
+		$this->init_form_fields();
+
+		// Load the settings.
+		$this->init_settings();
+
+    // Define user set variables.
+		$this->enabled            = $this->get_option( 'enabled', 'yes' );
+		$this->title              = $this->get_option( 'title' );
+		$this->declare_value      = $this->get_option( 'declare_value', 'no' );
+    $this->receipt_notice     = $this->get_option( 'receipt_notice', 'no' );
+    $this->own_hands          = $this->get_option( 'own_hands', 'no' );
+    $this->declare_value      = $this->get_option( 'declare_value', 'no' );
+		$this->show_delivery_time = $this->get_option( 'show_delivery_time', 'no' );
+		$this->additional_time    = $this->get_option( 'additional_time' );
+		$this->additional_fee     = $this->get_option( 'additional_fee' );
+    $this->debug              = $this->get_option( 'debug', 'no' );
+
+    // Method variables.
+    $this->availability       = 'specific';
+    $this->countries          = array( 'BR' );
+
+    // Active logs.
+    if ( 'yes' == $this->debug ) {
+      $this->log = new WC_Logger();
+    }
+
+		// Hooks.
+		add_filter( 'woocommerce_shipping_methods', array( $this, 'add_method' ) );
+		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
+  }
+
+	/**
+	 * Register the shipping method in Woocommerce.
+	 *
+	 * @param  string $method
+	 */
+	public function add_method( $methods ) {
+		$methods[] = get_called_class();
+
+		return $methods;
+	}
+
+  /**
+   * Admin options fields.
+   *
+   * @return void
+   */
+  public function init_form_fields() {
+    $this->form_fields = array(
+      'enabled' => array(
+        'title'            => __( 'Enable/disable', 'woocommerce-correios' ),
+        'type'             => 'checkbox',
+        'label'            => __( 'Enable this shipping method', 'woocommerce-correios' ),
+        'default'          => 'no'
+      ),
+      'title' => array(
+        'title'            => __( 'Title', 'woocommerce-correios' ),
+        'type'             => 'text',
+        'description'      => __( 'This controls the title which the user sees during checkout.', 'woocommerce-correios' ),
+        'desc_tip'         => true,
+        'default'          => __( $this->method_title, 'woocommerce-correios' )
+      ),
+      'show_delivery_time' => array(
+        'title'            => __( 'Delivery time', 'woocommerce-correios' ),
+        'type'             => 'checkbox',
+        'label'            => __( 'Show estimated delivery time', 'woocommerce-correios' ),
+        'description'      => __( 'Display the estimated delivery time in working days.', 'woocommerce-correios' ),
+        'desc_tip'         => true,
+        'default'          => 'no'
+      ),
+      'additional_time' => array(
+        'title'            => __( 'Additional days', 'woocommerce-correios' ),
+        'type'             => 'text',
+        'description'      => __( 'Additional working days to the estimated delivery.', 'woocommerce-correios' ),
+        'desc_tip'         => true,
+        'placeholder'      => '0'
+      ),
+      'additional_fee' => array(
+				'title'            => __( 'Handling fee', 'woocommerce-correios' ),
+				'type'             => 'text',
+				'description'      => __( 'Enter an amount, e.g. 2.50, or a percentage, e.g. 5%. Leave blank to disable.', 'woocommerce-correios' ),
+				'desc_tip'         => true,
+				'placeholder'      => '0.00'
+			)
+    );
+  }
+
+}

--- a/methods/class-wc-correios-esedex.php
+++ b/methods/class-wc-correios-esedex.php
@@ -1,0 +1,32 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_ESEDEX extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_esedex';
+		$this->method_title       = __( 'e-SEDEX', 'woocommerce-correios' );
+		$this->method_description = __( 'e-SEDEX is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/e-sedex">More about e-SEDEX</a>.', 'woocommerce-correios' );
+    /**
+  	 * 81019 - e-SEDEX with contract.
+  	 */
+    $this->code = WC_Correios::is_corporate() ? '81019' : '-1';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_ESEDEX();

--- a/methods/class-wc-correios-pac.php
+++ b/methods/class-wc-correios-pac.php
@@ -1,0 +1,33 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_PAC extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_pac';
+    $this->method_title       = __( 'PAC', 'woocommerce-correios' );
+		$this->method_description = __( 'PAC is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/pac-encomenda-economica">More about PAC</a>.', 'woocommerce-correios' );
+    /**
+     * 41106 - PAC without contract.
+     * 41068 - PAC with contract.
+  	 */
+		$this->code = WC_Correios::is_corporate() ? '41068' : '41106';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_PAC();

--- a/methods/class-wc-correios-registeredletter.php
+++ b/methods/class-wc-correios-registeredletter.php
@@ -1,0 +1,45 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_RegisteredLetter extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_registeredletter';
+		$this->method_title       = __( 'Registered Letter', 'woocommerce-correios' );
+		$this->method_description = __( 'Registered Letter is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/carta-comercial">More about Registered Letter</a>.', 'woocommerce-correios' );
+    /**
+  	 * 10014 - Registered Letter
+  	 */
+    $this->code = '10014';
+
+    parent::__construct();
+
+		$this->form_fields['price_table'] = array(
+			'title'       => __( 'Price table', 'woocommerce-correios' ),
+			'type'        => 'select',
+			'description' => __( 'Allow you to select between Commercial and Non-Commercial price table.', 'woocommerce-correios' ),
+			'desc_tip'    => true,
+			'default'     => 'commercial',
+			'options'			=> array(
+				'commercial' => __( 'Commercial', 'woocommerce-correios' ),
+				'noncommercial' => __( 'Non-Commercial', 'woocommerce-correios' ),
+			),
+		);
+
+  }
+
+}
+
+return new WC_Correios_RegisteredLetter();

--- a/methods/class-wc-correios-sedex.php
+++ b/methods/class-wc-correios-sedex.php
@@ -1,0 +1,33 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_SEDEX extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_sedex';
+		$this->method_title       = __( 'SEDEX', 'woocommerce-correios' );
+		$this->method_description = __( 'SEDEX is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/sedex">More about SEDEX</a>.', 'woocommerce-correios' );
+    /**
+  	 * 40010 - SEDEX without contract.
+  	 * 40096 - SEDEX with contract.
+  	 */
+    $this->code = WC_Correios::is_corporate() ? '40096' : '40010';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_SEDEX();

--- a/methods/class-wc-correios-sedex10.php
+++ b/methods/class-wc-correios-sedex10.php
@@ -1,0 +1,32 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_SEDEX10 extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_sedex10';
+		$this->method_title       = __( 'SEDEX 10', 'woocommerce-correios' );
+		$this->method_description = __( 'SEDEX 10 is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/sedex-10">More about SEDEX 10</a>.', 'woocommerce-correios' );
+    /**
+  	 * 40215 - SEDEX 10 without contract.
+  	 */
+    $this->code = '40215';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_SEDEX10();

--- a/methods/class-wc-correios-sedex12.php
+++ b/methods/class-wc-correios-sedex12.php
@@ -1,0 +1,32 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_SEDEX12 extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_sedex12';
+		$this->method_title       = __( 'SEDEX 12', 'woocommerce-correios' );
+		$this->method_description = __( 'SEDEX 12 is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/sedex-12">More about SEDEX 12</a>.', 'woocommerce-correios' );
+    /**
+  	 * xxxxx - SEDEX 12 without contract.
+  	 */
+    $this->code = '-1';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_SEDEX12();

--- a/methods/class-wc-correios-sedexhoje.php
+++ b/methods/class-wc-correios-sedexhoje.php
@@ -1,0 +1,32 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WC_Correios_Shipping class.
+ */
+class WC_Correios_SEDEXHoje extends WC_Correios_Method_Base {
+
+  /**
+	 * Initialize the shipping method.
+	 *
+	 * @return void
+	 */
+  public function __construct() {
+    //Initialize method specific variables.
+    $this->id                 = 'correios_sedexhoje';
+		$this->method_title       = __( 'SEDEX Hoje', 'woocommerce-correios' );
+		$this->method_description = __( 'SEDEX Hoje is a shipping method from Correios, the brazilian most used delivery company. <a href="http://www.correios.com.br/para-voce/correios-de-a-a-z/sedex-hoje">More about SEDEX Hoje</a>.', 'woocommerce-correios' );
+    /**
+  	 * 40290 - SEDEX Hoje without contract.
+  	 */
+    $this->code = '40290';
+
+    parent::__construct();
+  }
+
+}
+
+return new WC_Correios_SEDEXHoje();

--- a/woocommerce-correios.php
+++ b/woocommerce-correios.php
@@ -3,9 +3,9 @@
  * Plugin Name: WooCommerce Correios
  * Plugin URI: https://github.com/claudiosmweb/woocommerce-correios
  * Description: Correios para WooCommerce
- * Author: Claudio Sanches
- * Author URI: http://claudiosmweb.com/
- * Version: 2.3.0
+ * Author: Claudio Sanches, Thiago Benvenuto
+ * Author URI: http://claudiosmweb.com/, http://brdata.info/
+ * Version: 3.0.0
  * License: GPLv2 or later
  * Text Domain: woocommerce-correios
  * Domain Path: /languages/
@@ -27,7 +27,7 @@ class WC_Correios {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.3.0';
+	const VERSION = '3.0.0';
 
 	/**
 	 * Instance of this class.
@@ -51,10 +51,11 @@ class WC_Correios {
 				$this->admin_includes();
 			}
 
-			add_filter( 'woocommerce_shipping_methods', array( $this, 'add_method' ) );
 			add_action( 'wp_ajax_wc_correios_simulator', array( 'WC_Correios_Product_Shipping_Simulator', 'ajax_simulator' ) );
 			add_action( 'wp_ajax_nopriv_wc_correios_simulator', array( 'WC_Correios_Product_Shipping_Simulator', 'ajax_simulator' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
+
+			add_filter( 'woocommerce_shipping_settings', array( $this, 'add_custom_settings' ) );
 		} else {
 			add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
 		}
@@ -104,6 +105,14 @@ class WC_Correios {
 		include_once 'includes/class-wc-correios-product-shipping-simulator.php';
 		include_once 'includes/class-wc-correios-emails.php';
 		include_once 'includes/class-wc-correios-tracking-history.php';
+
+		include_once 'includes/class-wc-correios-method-base.php';
+
+		//Inclde all method classes.
+		foreach ( glob( plugin_dir_path( __FILE__ ) . 'methods/*.php' ) as $filename )
+		{
+				include_once $filename;
+		}
 	}
 
 	/**
@@ -111,6 +120,15 @@ class WC_Correios {
 	 */
 	private function admin_includes() {
 		include_once 'includes/admin/class-wc-correios-admin-orders.php';
+	}
+
+	/**
+	 * Check if the service type is set to corporate.
+	 *
+	 * @return bool
+	 */
+	public static function is_corporate() {
+		return get_option( 'woocommerce_correios_service_type', 'conventional' ) == 'corporate';
 	}
 
 	/**
@@ -129,16 +147,14 @@ class WC_Correios {
 	}
 
 	/**
-	 * Add the shipping method to WooCommerce.
+	 * Add the shipping methods to WooCommerce.
 	 *
-	 * @param   array $methods WooCommerce payment methods.
+	 * @param   array $methods WooCommerce shipping methods.
 	 *
-	 * @return  array          Payment methods with Correios.
+	 * @return  array          shipping methods with Correios registered methods.
 	 */
-	public function add_method( $methods ) {
-		$methods[] = 'WC_Correios_Shipping';
-
-		return $methods;
+	public function add_methods( $methods ) {
+		return array_merge( self::$registered_methods, $methods );
 	}
 
 	/**
@@ -148,6 +164,103 @@ class WC_Correios {
 	 */
 	public function woocommerce_missing_notice() {
 		echo '<div class="error"><p>' . sprintf( __( 'WooCommerce Correios depends on the last version of %s to work!', 'woocommerce-correios' ), '<a href="http://wordpress.org/plugins/woocommerce/">' . __( 'WooCommerce', 'woocommerce-correios' ) . '</a>' ) . '</p></div>';
+	}
+
+	/**
+	 * Add custom fields in Woocommerce Shipping settings tab.
+	 *
+	 * @param  array $settings Woocommerce existing settings
+	 *
+	 * @return array           New array of settings
+	 */
+	public function add_custom_settings ( $settings ) {
+		$new_settings = array(
+			array(
+				'name'          => __( 'Correios Options', 'woocommerce-correios' ),
+				'id'            => 'correios_settings',
+				'type'          => 'title',
+			),
+			array(
+				'name'          => __( 'Origin Postcode', 'woocommerce-correios' ),
+				'desc'          => __( 'The postcode of the location your packages are delivered from.', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_origin_postcode',
+				'type'          => 'text',
+				'css'           => 'min-width:350px;',
+				'std'           => '',  // WC < 2.0
+				'default'       => '',  // WC >= 2.0
+				'placeholder'   => '00000-000',
+				'desc_tip'      => true,
+			),
+			array(
+				'title'         => __( 'Optional Services', 'woocommerce-correios' ),
+				'desc'          => __( 'Receipt notice', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_receipt_notice',
+				'type'          => 'checkbox',
+				'checkboxgroup' => 'start',
+				'std'           => 'no', // WC < 2.0
+				'default'       => 'no', // WC >= 2.0
+				'desc_tip'      => __( 'This controls if the sender must receive a receipt notice when a package is delivered.', 'woocommerce-correios' ),
+			),
+			array(
+				'desc'          => __( 'Own hands', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_own_hands',
+				'type'          => 'checkbox',
+				'checkboxgroup' => '',
+				'std'           => 'no', // WC < 2.0
+				'default'       => 'no', // WC >= 2.0
+				'desc_tip'      => __( 'This controls if the package must be delivered exclusively to the recipient printed in its label.', 'woocommerce-correios' ),
+			),
+			array(
+				'desc'          => __( 'Declare value for insurance', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_declare_value',
+				'type'          => 'checkbox',
+				'checkboxgroup' => 'end',
+				'std'           => 'no', // WC < 2.0
+				'default'       => 'no', // WC >= 2.0
+				'desc_tip'      => __( 'This controls if the price of the package must be declared for insurance purposes.', 'woocommerce-correios' ),
+			),
+			array(
+				'name'          => __( 'Service Type', 'woocommerce-correios' ),
+				'desc'          => __( 'Choose between conventional or corporate service.', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_service_type',
+				'type'          => 'select',
+				'css'           => 'min-width:350px;',
+				'std'           => 'conventional',  // WC < 2.0
+				'default'       => 'conventional',  // WC >= 2.0
+				'options'       => array(
+					'conventional' => __( 'Conventional', 'woocommerce-correios' ),
+					'corporate'    => __( 'Corporate', 'woocommerce-correios' )
+				),
+				'desc_tip'      => true,
+				'class'         => 'wc-enhanced-select',
+			),
+			array(
+				'name'          => __( 'Administrative Code', 'woocommerce-correios' ),
+				'desc'          => __( 'Your Correios login.', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_login',
+				'type'          => 'text',
+				'css'           => 'min-width:350px;',
+				'std'           => '',  // WC < 2.0
+				'default'       => '',  // WC >= 2.0
+				'desc_tip'      => true,
+			),
+			array(
+				'name'          => __( 'Administrative Password', 'woocommerce-correios' ),
+				'desc'          => __( 'Your Correios password.', 'woocommerce-correios' ),
+				'id'            => 'woocommerce_correios_password',
+				'type'          => 'password',
+				'css'           => 'min-width:350px;',
+				'std'           => '',  // WC < 2.0
+				'default'       => '',  // WC >= 2.0
+				'desc_tip'      => true,
+			),
+			array(
+				'id'            => 'correios_settings',
+				'type'          => 'sectionend',
+			),
+		);
+
+		return array_merge( $new_settings, $settings );
 	}
 }
 


### PR DESCRIPTION
Uma opção de deixar um pacote por produto no cálculo da encomenda. 

Existem lojas que o produto é pesado, ou embalagem larga ou até mesmo caro. Seja qual for, o cliente adicionando 2 ou mais produtos na cestas o plugin atual não retorna qualquer valor.

Um produto de 6 mil reais, não pode ter dois em uma mesma encomenda de valor declarado.
Um produto de 50x30x50 também ultrapassaria 200cm² ao adiconar dois deles.
Um produto de 16 kg ou mais mesma coisa.


Esta opção resolveria isso de forma mais organizada para a loja. Não sei como ficaria no front end. De qualquer forma, poderia dar incompatibilidade com plugins de terceiros a respeito de tracking. Uma solução paleativa seria se fosse o caso, a opção de entrega um pacote por cada produto gerar um numero de pedido separadadmente.

Não sei.

Espero que consigam.
Muito obrigado.

att
kaiuaki