### PR TITLE
Update class-wc-correios-package.php

### DIFF
--- a/includes/class-wc-correios-package.php
+++ b/includes/class-wc-correios-package.php
@@ -31,7 +31,8 @@ class WC_Correios_Package {
 	 * @return array
 	 */
 	public function __construct( $package = array() ) {
-		$this->package = $package;
+		$this->package = $package;			
+		do_action('wc_correios_package_constructed',$package);	
 	}
 
 	/**


### PR DESCRIPTION
Claudio, excelente plugin! Depois de horas de análise em seu plugin com o objetivo de integrar uma solução multivendor enganchada, cheguei a conclusão que seria necessário incluir um gancho para passar a variável $package pois o filtro woocommerce_correios_origin_postcode não passava esta informação e nem existia nenhum gancho relacionado no seu código. Esta é minha sugestão para incluir um gancho de ação no seu código.