### PR TITLE
Corrigido bug nao calcula frete;

### DIFF
--- a/includes/class-wc-correios-webservice.php
+++ b/includes/class-wc-correios-webservice.php
@@ -368,7 +368,7 @@ class WC_Correios_Webservice {
 	 * @param string $declared_value Declared value.
 	 */
 	public function set_declared_value( $declared_value = '0' ) {
-		$this->declared_value = $declared_value;
+		$this->declared_value = ($declared_value>18 && $declared_value<21) ? 21 : $declared_value;
 	}
 
 	/**


### PR DESCRIPTION
Existe um bug que não deixa calcular o frete de produtos com o preço entre 18,01 á 20,49, com essa linha de código, o bug é corrigido