### PR TITLE
Fix declared value minimum amount

### DIFF
--- a/includes/shipping/class-wc-correios-shipping-cws.php
+++ b/includes/shipping/class-wc-correios-shipping-cws.php
@@ -263,7 +263,7 @@ class WC_Correios_Shipping_Cws extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 24 >= $package['contents_cost'] ) {
+		if ( 24.5 > $package['contents_cost'] ) {
 			return 0;
 		}
 


### PR DESCRIPTION
Se enviar menos de `24.5` como valor declarado, a API retorna status 400:

```json
"msgs": [
	"ERP-013: Vlr declarado nao permitido, aceito entre R$ 24,50 e R$ 10000,00."
]
```

Para o sedex o limite é 10 mil e para o PAC o limite é 3 mil. Não mudei isso, pois não sei a lógica que você vai preferir implementar ali.