### PR TITLE
fix: Correção para aceitar unidade de medida kg ou g

### DIFF
--- a/includes/class-wc-correios-package.php
+++ b/includes/class-wc-correios-package.php
@@ -54,7 +54,7 @@ class WC_Correios_Package {
 				$_height = wc_get_dimension( (float) $product->get_height(), 'cm' );
 				$_width  = wc_get_dimension( (float) $product->get_width(), 'cm' );
 				$_length = wc_get_dimension( (float) $product->get_length(), 'cm' );
-				$_weight = wc_get_weight( (float) $product->get_weight(), 'kg' );
+				$_weight = wc_get_weight( (float) $product->get_weight(), get_option('woocommerce_weight_unit') );
 
 				$height[ $count ] = $_height;
 				$width[ $count ]  = $_width;


### PR DESCRIPTION
O código estava forçando o cálculo de peso com quilos causando erro no cálculo de frete de quem utiliza o WooCommerce com gramas.